### PR TITLE
[Slides] OT245-62 - Add slides to a public endpoint

### DIFF
--- a/controllers/organizations.js
+++ b/controllers/organizations.js
@@ -1,16 +1,18 @@
 const createHttpError = require('http-errors')
 const { getOrganizations, updateOrganization } = require('../services/organizations')
 const { endpointResponse } = require('../helpers/success')
+const { listSlideByOrder } = require('../services/slides')
 const { catchAsync } = require('../helpers/catchAsync')
 
 module.exports = {
   get: catchAsync(async (req, res, next) => {
     try {
       const response = await getOrganizations()
+      const publicSlide = await listSlideByOrder()
       endpointResponse({
         res,
         message: 'Organization information',
-        body: response,
+        body: [response, publicSlide],
       })
     } catch (error) {
       const httpError = createHttpError(

--- a/services/slides.js
+++ b/services/slides.js
@@ -12,6 +12,15 @@ exports.getSlides = async () => {
   }
 }
 
+exports.listSlideByOrder = async () => {
+  try {
+    const orderedSlides = await Slide.findAll({ order: [['order', 'ASC']] })
+    return orderedSlides
+  } catch (error) {
+    throw new ErrorObject(error.message, error.statusCode || 500)
+  }
+}
+
 exports.getSlideById = async (id) => {
   try {
     const slides = await Slide.findByPk(id)


### PR DESCRIPTION
[https://alkemy-labs.atlassian.net/browse/OT245-62](url)

**Description**

AS user
I WANT to see Slides when I enter the page
TO be more informed about them

**Criteria of acceptance:**

In the public data endpoint of the Organization, the list of Slides ordered by the "order" field must be added.

The Slides will be those belonging to the Organization, based on the organization_id field that should correspond to the Organization that is being returned.

**EVIDENCE:**

**Organization** 
![Organizaccion](https://user-images.githubusercontent.com/98825779/181683543-df0df777-3ce2-49ed-896b-4f0c9088a091.png)

**Order**
![order](https://user-images.githubusercontent.com/98825779/181683650-cac3c6a2-abbd-426f-ad95-5b8c40ad9e48.png)


