### PR TITLE
[OT245-78] add middlewares to protect admin routes

### DIFF
--- a/routes/activities.js
+++ b/routes/activities.js
@@ -3,10 +3,11 @@ const { post, put } = require('../controllers/activities')
 const { schemaValidator } = require('../middlewares/validator')
 const { activity } = require('../schemas/activities')
 const { verifyAdmin } = require('../middlewares/admin')
+const { validateToken } = require('../middlewares/validateUser')
 
 const router = express.Router()
 
-router.post('/', verifyAdmin, schemaValidator(activity), post)
-router.put('/:id', verifyAdmin, put)
+router.post('/', validateToken, verifyAdmin, schemaValidator(activity), post)
+router.put('/:id', validateToken, verifyAdmin, put)
 
 module.exports = router

--- a/routes/activities.js
+++ b/routes/activities.js
@@ -2,10 +2,11 @@ const express = require('express')
 const { post, put } = require('../controllers/activities')
 const { schemaValidator } = require('../middlewares/validator')
 const { activity } = require('../schemas/activities')
+const { verifyAdmin } = require('../middlewares/admin')
 
 const router = express.Router()
 
-router.post('/', schemaValidator(activity), post)
-router.put('/:id', put)
+router.post('/', verifyAdmin, schemaValidator(activity), post)
+router.put('/:id', verifyAdmin, put)
 
 module.exports = router

--- a/routes/categories.js
+++ b/routes/categories.js
@@ -8,13 +8,14 @@ const {
   post,
   destroy,
 } = require('../controllers/categories')
+const { verifyAdmin } = require('../middlewares/admin')
 
 const router = express.Router()
 
 router.get('/', get)
 router.get('/:id', getCategoryById)
-router.post('/', schemaValidator(category), post)
-router.put('/:id', put)
-router.delete('/:id', destroy)
+router.post('/', verifyAdmin, schemaValidator(category), post)
+router.put('/:id', verifyAdmin, put)
+router.delete('/:id', verifyAdmin, destroy)
 
 module.exports = router

--- a/routes/categories.js
+++ b/routes/categories.js
@@ -9,13 +9,14 @@ const {
   destroy,
 } = require('../controllers/categories')
 const { verifyAdmin } = require('../middlewares/admin')
+const { validateToken } = require('../middlewares/validateUser')
 
 const router = express.Router()
 
 router.get('/', get)
 router.get('/:id', getCategoryById)
-router.post('/', verifyAdmin, schemaValidator(category), post)
-router.put('/:id', verifyAdmin, put)
-router.delete('/:id', verifyAdmin, destroy)
+router.post('/', validateToken, verifyAdmin, schemaValidator(category), post)
+router.put('/:id', validateToken, verifyAdmin, put)
+router.delete('/:id', validateToken, verifyAdmin, destroy)
 
 module.exports = router

--- a/routes/news.js
+++ b/routes/news.js
@@ -8,12 +8,13 @@ const {
 const { schemaValidator } = require('../middlewares/validator')
 const { news } = require('../schemas/news')
 const { verifyAdmin } = require('../middlewares/admin')
+const { validateToken } = require('../middlewares/validateUser')
 
 const router = express.Router()
 
-router.post('/', verifyAdmin, schemaValidator(news), post)
+router.post('/', validateToken, verifyAdmin, schemaValidator(news), post)
 router.get('/:id', getById)
-router.put('/:id', verifyAdmin, put)
-router.delete('/:id', verifyAdmin, destroy)
+router.put('/:id', validateToken, verifyAdmin, put)
+router.delete('/:id', validateToken, verifyAdmin, destroy)
 
 module.exports = router

--- a/routes/news.js
+++ b/routes/news.js
@@ -7,12 +7,13 @@ const {
 } = require('../controllers/news')
 const { schemaValidator } = require('../middlewares/validator')
 const { news } = require('../schemas/news')
+const { verifyAdmin } = require('../middlewares/admin')
 
 const router = express.Router()
 
-router.post('/', schemaValidator(news), post)
+router.post('/', verifyAdmin, schemaValidator(news), post)
 router.get('/:id', getById)
-router.put('/:id', put)
-router.delete('/:id', destroy)
+router.put('/:id', verifyAdmin, put)
+router.delete('/:id', verifyAdmin, destroy)
 
 module.exports = router

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -5,13 +5,14 @@ const {
 const { validateFiles } = require('../middlewares/validateFiles')
 const { schemaValidator } = require('../middlewares/validator')
 const { slides } = require('../schemas/slides')
+const { verifyAdmin } = require('../middlewares/admin')
 
 const router = express.Router()
 
 router.get('/', get)
 router.get('/:id', getById)
-router.delete('/:id', destroy)
-router.put('/:id', put)
-router.post('/', [validateFiles, schemaValidator(slides)], post)
+router.delete('/:id', verifyAdmin, destroy)
+router.put('/:id', verifyAdmin, put)
+router.post('/', [verifyAdmin, validateFiles, schemaValidator(slides)], post)
 
 module.exports = router

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -6,13 +6,14 @@ const { validateFiles } = require('../middlewares/validateFiles')
 const { schemaValidator } = require('../middlewares/validator')
 const { slides } = require('../schemas/slides')
 const { verifyAdmin } = require('../middlewares/admin')
+const { validateToken } = require('../middlewares/validateUser')
 
 const router = express.Router()
 
 router.get('/', get)
 router.get('/:id', getById)
-router.delete('/:id', verifyAdmin, destroy)
-router.put('/:id', verifyAdmin, put)
-router.post('/', [verifyAdmin, validateFiles, schemaValidator(slides)], post)
+router.delete('/:id', validateToken, verifyAdmin, destroy)
+router.put('/:id', validateToken, verifyAdmin, put)
+router.post('/', [validateToken, verifyAdmin, validateFiles, schemaValidator(slides)], post)
 
 module.exports = router

--- a/services/users.js
+++ b/services/users.js
@@ -64,9 +64,8 @@ exports.createLogin = async (email, password) => {
     if (user) {
       const hash = user.password
       const login = this.getPassword(password, hash)
-      const token = await generateToken(user)
       if (login) {
-        return [user, token]
+        return user
       }
     }
     return null

--- a/services/users.js
+++ b/services/users.js
@@ -64,8 +64,9 @@ exports.createLogin = async (email, password) => {
     if (user) {
       const hash = user.password
       const login = this.getPassword(password, hash)
+      const token = await generateToken(user)
       if (login) {
-        return user
+        return [user, token]
       }
     }
     return null


### PR DESCRIPTION
[OT245-78](https://alkemy-labs.atlassian.net/browse/OT245-78?atlOrigin=eyJpIjoiNjM0NjBjOGFjYzhlNGFlYTkwYzcyMDBkMGU2NWY2OTAiLCJwIjoiaiJ9)

AS admin user
I WANT to control access to certain content
TO keep data protected

Criteria of acceptance:
The middlewares get added to avoid the operations of creating, updating and deleting the entities of the system.

Evidence:

with roleId 2 (Standard user):
![evidenceAdmin1](https://user-images.githubusercontent.com/38705539/182886272-a708a0ac-b211-4af7-8e0b-bc2c9dee4a2e.png)
![evidenceAdmin2](https://user-images.githubusercontent.com/38705539/182886287-7bab08bd-85dd-46da-8c89-36bf68530126.png)

with roleId 1 (Admin):
![evidenceAdmin3](https://user-images.githubusercontent.com/38705539/182886331-2080d3b8-478d-4d95-bd8d-5069be153623.png)
![evidenceAdmin4](https://user-images.githubusercontent.com/38705539/182886351-de7935ad-a762-4905-bf49-9e7faf404f99.png)

