### PR TITLE
Fix user

### DIFF
--- a/services/users.js
+++ b/services/users.js
@@ -12,7 +12,7 @@ exports.createUser = async (body) => {
     }
     const hashedPassword = await bcrypt.hash(body.password, 10)
     body.password = hashedPassword
-    body.roleId = 1
+    body.roleId = 2
     const newUser = await User.create(body)
     if (!newUser) {
       throw new ErrorObject('User registration failed', 404)

--- a/services/users.js
+++ b/services/users.js
@@ -19,7 +19,7 @@ exports.createUser = async (body) => {
     }
     await postMail(newUser.email)
     const token = await generateToken(newUser)
-    return token
+    return { newUser, token }
   } catch (error) {
     throw new ErrorObject(error.message, error.statusCode || 500)
   }

--- a/services/users.js
+++ b/services/users.js
@@ -64,8 +64,9 @@ exports.createLogin = async (email, password) => {
     if (user) {
       const hash = user.password
       const login = this.getPassword(password, hash)
+      const token = await generateToken(user)
       if (login) {
-        return user
+        return { user, token }
       }
     }
     return null


### PR DESCRIPTION
**Description:** 

USER: when the user is created, it only returns the token and not the body, it must return both
USER: when logging in the user is not returning the token, it must return the token and the body
USER: when a user is created, the default role that is given is admin, it must be standard

**Evidence:**
**Create user**
![image](https://user-images.githubusercontent.com/88119333/184208988-25b0373f-3fc8-4265-ab44-b78c1d239563.png)
**login a user**
![image](https://user-images.githubusercontent.com/88119333/184209074-fed37146-1207-4c97-b810-16a9a2b21dcb.png)
