### PR TITLE
[Documentation - Categories]  "OT245-90 Add documentation to category endpoint"

### DIFF
--- a/controllers/categories.js
+++ b/controllers/categories.js
@@ -9,6 +9,319 @@ const {
   deleteCategory,
 } = require('../services/categories')
 
+/**
+  * @swagger
+  * components:
+  *  schemas:
+  *     Category:
+  *       type: object
+  *       properties:
+  *         id:
+  *           type: integer
+  *         name:
+  *           type: string
+  *         description:
+  *           type: string
+  *         image:
+  *           type: string
+  *         createdAt:
+  *           type: integer
+  *           format: date
+  *         updatedAt:
+  *           type: integer
+  *           format: date
+  *         deletedAt:
+  *           type: integer
+  *           format: date
+  *       example:
+  *         name: category name
+  *         description: some description
+  *         image: https://someurl.to/a-picture.png
+  *         createdAt: 2022-08-09 19:50:30
+  *         updatedAt: 2022-08-09 19:50:30
+  *         deletedAt: null
+  *
+  */
+
+/**
+  * @swagger
+  *  /categories:
+  *  post:
+  *   summary: create categories
+  *   tags: [Category]
+  *   requestBody:
+  *     required: true
+  *     content:
+  *       application/json:
+  *         schema:
+  *           type: object
+  *           $ref: '#/components/schemas/Category'
+  *   responses:
+  *     200:
+  *       description: category created successfuly
+  *       content:
+  *         application/json:
+  *           schema:
+  *             type: object
+  *             properties:
+  *               status:
+  *                 type: boolean
+  *               code:
+  *                 type: integer
+  *               message:
+  *                 type: string
+  *               body:
+  *                 type: object
+  *                 properties:
+  *                   id:
+  *                     type: integer
+  *                   name:
+  *                     type: string
+  *                   description:
+  *                     type: string
+  *                   image:
+  *                     type: string
+  *                   createdAt:
+  *                     type: string
+  *                     format: date-time
+  *                   updatedAt:
+  *                     type: string
+  *                     format: date-time
+  *                   deletedAt:
+  *                     type: string
+  *                     format: date-time
+  *             example:
+  *               status: true
+  *               code: 200
+  *               message: category created successfuly
+  *               body:
+  *                 id: 1
+  *                 name: category name
+  *                 description: some description
+  *                 image: someurl.to/some-image.png
+  *                 createdAt: 2022-08-09 19:50:30
+  *                 updatedAt: 2022-08-09 19:50:30
+  *     401:
+  *       description: Unauthorized user
+  *     403:
+  *       description: Token is required
+  *     500:
+  *       description: Internal server error
+  *
+  */
+
+/**
+  * @swagger
+  *  /categories/{id}:
+  *  delete:
+  *   summary: create categories
+  *   tags: [Category]
+  *   parameters:
+  *     - in: path
+  *       name: id
+  *       schema:
+  *         type: integer
+  *       required: true
+  *       description: Numeric ID of the category to delete
+  *   responses:
+  *     200:
+  *       description: category deleted successfuly
+  *       content:
+  *         application/json:
+  *           schema:
+  *             type: object
+  *             properties:
+  *               status:
+  *                 type: boolean
+  *               code:
+  *                 type: integer
+  *               message:
+  *                 type: string
+  *               body:
+  *                 type: array
+  *                 items:
+  *                   type: integer
+  *             example:
+  *               status: true
+  *               code: 200
+  *               message: category deleted successfuly
+  *               body: 1
+  *     401:
+  *       description: Unauthorized user
+  *     403:
+  *       description: Token is required
+  *     404:
+  *       description: Category not found
+  *     500:
+  *       description: Internal server error
+  */
+
+/**
+  * @swagger
+  *  /categories/{id}:
+  *  put:
+  *   summary: update categories
+  *   tags: [Category]
+  *   parameters:
+  *     - in: path
+  *       name: id
+  *       schema:
+  *         type: integer
+  *       required: true
+  *       description: Numeric ID of the category to update
+  *   requestBody:
+  *     required: true
+  *     content:
+  *       application/json:
+  *         schema:
+  *           type: object
+  *           $ref: '#/components/schemas/Category'
+  *   responses:
+  *     200:
+  *       description: category update successfuly
+  *       content:
+  *         application/json:
+  *           schema:
+  *             type: object
+  *             properties:
+  *               status:
+  *                 type: boolean
+  *               code:
+  *                 type: integer
+  *               message:
+  *                 type: string
+  *               body:
+  *                 type: object
+  *                 properties:
+  *                   id:
+  *                     type: integer
+  *                   name:
+  *                     type: string
+  *                   description:
+  *                     type: string
+  *                   image:
+  *                     type: string
+  *                   createdAt:
+  *                     type: string
+  *                     format: date-time
+  *                   updatedAt:
+  *                     type: string
+  *                     format: date-time
+  *                   deletedAt:
+  *                     type: string
+  *                     format: date-time
+  *             example:
+  *               status: true
+  *               code: 200
+  *               message: category updated successfuly
+  *               body:
+  *                 id: 1
+  *                 name: category new name
+  *                 description: some description
+  *                 image: someurl.to/some-image.png
+  *                 createdAt: 2022-08-09 19:50:30
+  *                 updatedAt: 2022-08-09 19:50:30
+  *     401:
+  *       description: Unauthorized user
+  *     403:
+  *       description: Token is required
+  *     404:
+  *       description: Category not found
+  *     500:
+  *       description: Internal server error
+  *
+  */
+
+/**
+ * @swagger
+ * /category:
+ *  get:
+ *    tags: [Category]
+ *    summary: List of categories.
+ *    responses:
+ *      200:
+ *        description: List of categories in database.
+ *        content:
+ *          application/json:
+ *            schema:
+ *            type: array
+ *            items:
+ *              properties:
+ *                id:
+ *                  type: integer
+ *                  example: 1
+ *                name:
+ *                  type: string
+ *                  example: category name
+ *                description:
+ *                  type: string
+ *                  example: some description
+ *                image:
+ *                  type: string
+ *                  example: https://image.com/category1.jpg
+ */
+
+/**
+  * @swagger
+  * /categories/{id}:
+  *  get:
+  *   tags: [Category]
+  *   summary: get a category detail categories
+  *   parameters:
+  *     - in: path
+  *       name: id
+  *       schema:
+  *         type: integer
+  *       required: true
+  *       description: Numeric ID of the category to search
+  *   responses:
+  *    200:
+  *     description: category detail successfuly
+  *     content:
+  *       application/json:
+  *         schema:
+  *           type: object
+  *           properties:
+  *             status:
+  *               type: boolean
+  *             code:
+  *               type: integer
+  *             message:
+  *               type: string
+  *             body:
+  *               type: object
+  *               properties:
+  *                 id:
+  *                   type: integer
+  *                 name:
+  *                   type: string
+  *                 description:
+  *                   type: string
+  *                 image:
+  *                   type: string
+  *                 createdAt:
+  *                   type: string
+  *                   format: date-time
+  *                 updatedAt:
+  *                   type: string
+  *                   format: date-time
+  *                 deletedAt:
+  *                   type: string
+  *                   format: date-time
+  *           example:
+  *             status: true
+  *             code: 200
+  *             message: category detail successfuly
+  *             body:
+  *               id: 1
+  *               name: category name
+  *               description: some description
+  *               image: someurl.to/some-image.png
+  *               createdAt: 2022-08-09 19:50:30
+  *               updatedAt: 2022-08-09 19:50:30
+  *
+*/
+
 module.exports = {
   get: catchAsync(async (req, res, next) => {
     try {


### PR DESCRIPTION
Description

AS developer
I WANT to have a documentation of the Categories endpoints
TO HAVE REFERENCES OF ITS OPERATION

Criteria of acceptance:
The different endpoints must be documented, specifying the data model, mandatory fields, request format and its example.

Evidence:
![swagger3](https://user-images.githubusercontent.com/89169505/184249949-c5ddbc7f-ab4e-4c03-a6b9-b6e3fe1fff6b.jpg)
![swagger1](https://user-images.githubusercontent.com/89169505/184249957-4ab9bc31-af21-4794-a6a4-f344f95c22cc.jpg)
![swagger2](https://user-images.githubusercontent.com/89169505/184249960-b66c48f1-4599-4f30-92e3-f543c6b3d1c5.jpg)

